### PR TITLE
Adding compatible envs file to the correct location

### DIFF
--- a/templates/cds-protonpoc-serviceprotontemplate/v1/.compatible-envs
+++ b/templates/cds-protonpoc-serviceprotontemplate/v1/.compatible-envs
@@ -1,0 +1,1 @@
+cds-protonpoc-environment-temp:1


### PR DESCRIPTION
The `.compatible-envs` file needs to be located in the service template bundle.